### PR TITLE
Improve extraction of suggested follow-up question

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,14 +8,20 @@ from ai_council import council, session, utils, ui
 from ai_council.utils import logger
 
 def extract_suggested_question(report: str) -> str | None:
-    """Uses regex to find the question within the 'QUESTION' callout block."""
-    # This pattern looks for the text between the callout title and the end of the line
-    match = re.search(r'>\s*\[!QUESTION\]\s*.*\n>\s*(.*)', report, re.MULTILINE)
+    """Extracts the follow-up question from the report.
+
+    Anchors on the 'Suggested Follow-Up Question' heading and returns the first
+    `[!QUESTION]` block that follows.
+    """
+
+    pattern = (
+        r"(?s)^###.*Suggested Follow-Up Question.*?"  # Heading
+        r"^>\s*\[!QUESTION\].*?\n"                   # Start of callout
+        r">\s*(.+?)\s*$"                             # Question line
+    )
+    match = re.search(pattern, report, re.MULTILINE)
     if match:
-        # Clean up the extracted question
-        question = match.group(1).strip()
-        # Remove markdown bolding if present
-        question = question.replace('**', '')
+        question = match.group(1).strip().replace("**", "")
         return question
     return None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from ai_council.utils import load_config, generate_filename_slug, write_audit_log
+from main import extract_suggested_question
 
 
 class DummyClient:
@@ -62,3 +63,19 @@ def test_write_audit_log(tmp_path, monkeypatch):
     with open(p, "r", encoding="utf-8") as f:
         data = json.load(f)
     assert data == {"a": 1}
+
+
+def test_extract_suggested_question():
+    report = """\
+### 3. Synthesis & Proposed Path Forward
+> [!QUESTION]
+> Should we increase marketing spend?
+
+### 4. Suggested Follow-Up Question for the Council
+> [!QUESTION]
+> **What metrics** should we track to measure success?
+"""
+    assert (
+        extract_suggested_question(report)
+        == "What metrics should we track to measure success?"
+    )


### PR DESCRIPTION
## Summary
- refine regex in `extract_suggested_question` to target the "Suggested Follow-Up Question" heading
- add unit test for the new regex behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d5ace6d8832397f589e9c0a2181e