### PR TITLE
Fix turn cost calc and add tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,7 +73,8 @@ async def main():
         state = await council.run_turn(client, state, prompts_config, council_prompt)
 
         # D. Update and save state
-        turn_cost = state['total_session_cost'] - sum(t.get('total_cost', 0) for t in state['session_log'])
+        previous_total = state['session_log'][-1]['total_cost'] if state['session_log'] else 0
+        turn_cost = state['total_session_cost'] - previous_total
         ui.display_turn_telemetry(turn_cost, state['total_session_cost'], state['turn_counter'])
         state['session_log'].append({"turn": state['turn_counter'], "user_prompt": state['last_user_input'], "rapporteur_report": state['last_rapporteur_report'], "total_cost": state['total_session_cost']})
         state['turn_counter'] += 1

--- a/tests/test_turn_cost.py
+++ b/tests/test_turn_cost.py
@@ -1,0 +1,22 @@
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import main
+
+
+def calculate_turn_cost(state):
+    previous_total = state['session_log'][-1]['total_cost'] if state['session_log'] else 0
+    return state['total_session_cost'] - previous_total
+
+def test_turn_cost_multiple_turns():
+    state = {'session_log': [], 'total_session_cost': 0.5}
+    assert calculate_turn_cost(state) == 0.5
+
+    state['session_log'].append({'total_cost': 0.5})
+    state['total_session_cost'] = 0.75
+    assert calculate_turn_cost(state) == 0.25
+
+    state['session_log'].append({'total_cost': 0.75})
+    state['total_session_cost'] = 1.25
+    assert calculate_turn_cost(state) == 0.5


### PR DESCRIPTION
## Summary
- compute previous total before calculating current turn cost
- test turn cost across multiple turns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e814a8588323850def855af57d0a